### PR TITLE
package.json has non-existent file for "main" option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rateyo",
   "version": "2.3.3",
   "description": "A simple and flexible star rating plugin",
-  "main": "js/jquery.rateyo.js",
+  "main": "src/jquery.rateyo.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/prrashi/rateYo.git"


### PR DESCRIPTION
I'm not super familiar with this stuff, so I'm not sure if I did this right.

I was having trouble getting the plugin to register properly in webpack. The `js/jquery.rateyo.js` that `main` previously pointed to, doesn't exist in the project.